### PR TITLE
Fix chain genesis initialization

### DIFF
--- a/pygeth/accounts.py
+++ b/pygeth/accounts.py
@@ -3,12 +3,6 @@ import re
 
 from .wrapper import spawn_geth
 from .utils.proc import format_error_message
-from .chain import (
-    get_genesis_file_path,
-    is_live_chain,
-    is_testnet_chain,
-    write_genesis_file,
-)
 
 
 def get_accounts(data_dir, **geth_kwargs):
@@ -84,20 +78,6 @@ def ensure_account_exists(data_dir, **geth_kwargs):
     accounts = get_accounts(data_dir, **geth_kwargs)
     if not accounts:
         account = create_new_account(data_dir, **geth_kwargs)
-        genesis_file_path = get_genesis_file_path(data_dir)
-
-        should_write_genesis = not any((
-            os.path.exists(genesis_file_path),
-            is_live_chain(data_dir),
-            is_testnet_chain(data_dir),
-        ))
-        if should_write_genesis:
-            write_genesis_file(
-                genesis_file_path,
-                alloc=dict([
-                    (account, "1000000000000000000000000000"),  # 1 billion ether.
-                ]),
-            )
     else:
         account = accounts[0]
     return account

--- a/pygeth/chain.py
+++ b/pygeth/chain.py
@@ -3,6 +3,7 @@ import json
 import sys
 
 
+from .wrapper import spawn_geth
 from .utils.encoding import (
     force_obj_to_text,
 )
@@ -106,3 +107,20 @@ def write_genesis_file(genesis_file_path,
 
     with open(genesis_file_path, 'w') as genesis_file:
         genesis_file.write(json.dumps(force_obj_to_text(genesis_data)))
+
+
+def initialize_chain(genesis_data, data_dir, **geth_kwargs):
+    genesis_file_path = get_genesis_file_path(data_dir)
+    write_genesis_file(
+        genesis_file_path,
+        **genesis_data
+    )
+    command, proc = spawn_geth(dict(
+        data_dir=data_dir,
+        suffix_args=['init', genesis_file_path],
+        **geth_kwargs
+    ))
+    stdoutdata, stderrdata = proc.communicate()
+
+    if proc.returncode:
+        raise ValueError("Error: {0}".format(stdoutdata + stderrdata))

--- a/pygeth/geth.py
+++ b/pygeth/geth.py
@@ -147,7 +147,7 @@ class DevGethProcess(BaseGethProcess):
         if needs_init or True:
             genesis_data = {
                 'alloc': dict([
-                    (coinbase, {"balance": "1000000000000000000000000000"}),  # 1 billion ether.
+                    (coinbase, {"balance": "1000000000000000000000000000000"}),  # 1 billion ether.
                 ]),
             }
             initialize_chain(genesis_data, self.data_dir, **geth_kwargs)

--- a/pygeth/geth.py
+++ b/pygeth/geth.py
@@ -14,10 +14,14 @@ from .wrapper import (
     construct_popen_command,
 )
 from .chain import (
-    get_default_base_dir,
     get_chain_data_dir,
+    get_default_base_dir,
+    get_genesis_file_path,
     get_live_data_dir,
     get_testnet_data_dir,
+    initialize_chain,
+    is_live_chain,
+    is_testnet_chain,
 )
 
 
@@ -128,7 +132,25 @@ class DevGethProcess(BaseGethProcess):
         geth_kwargs = construct_test_chain_kwargs(**overrides)
         self.data_dir = get_chain_data_dir(base_dir, chain_name)
 
-        ensure_account_exists(self.data_dir, **geth_kwargs)
+        # ensure that an account is present
+        coinbase = ensure_account_exists(self.data_dir, **geth_kwargs)
+
+        # ensure that the chain is initialized
+        genesis_file_path = get_genesis_file_path(self.data_dir)
+
+        needs_init = tuple((
+            not os.path.exists(genesis_file_path),
+            not is_live_chain(self.data_dir),
+            not is_testnet_chain(self.data_dir),
+        ))
+
+        if needs_init or True:
+            genesis_data = {
+                'alloc': dict([
+                    (coinbase, {"balance": "1000000000000000000000000000"}),  # 1 billion ether.
+                ]),
+            }
+            initialize_chain(genesis_data, self.data_dir, **geth_kwargs)
 
         geth_kwargs['data_dir'] = self.data_dir
 

--- a/pygeth/logging.py
+++ b/pygeth/logging.py
@@ -48,7 +48,7 @@ def stream_to_queues(stream, *queues):
     for line in iter(stream.readline, b''):
         for queue in queues:
             queue.put(line)
-            gevent.sleep(0.1)
+        gevent.sleep(0.1)
 
 
 def queue_to_logger(queue, *logger_functions):
@@ -56,7 +56,7 @@ def queue_to_logger(queue, *logger_functions):
         line = queue.get()
         for fn in logger_functions:
             fn(line)
-            gevent.sleep(0.1)
+        gevent.sleep(0.1)
 
 
 class LoggingMixin(object):

--- a/pygeth/utils/proc.py
+++ b/pygeth/utils/proc.py
@@ -1,11 +1,13 @@
 import time
 import signal
 
+import gevent
+
 
 def wait_for_popen(proc, max_wait=5):
     wait_till = time.time() + 5
     while proc.poll() is None and time.time() < wait_till:
-        time.sleep(0.1)
+        gevent.sleep(0.1)
 
 
 def kill_proc(proc):

--- a/pygeth/wrapper.py
+++ b/pygeth/wrapper.py
@@ -20,14 +20,12 @@ PYGETH_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 DEFAULT_PASSWORD_PATH = os.path.join(PYGETH_DIR, 'default_blockchain_password')
-DEFAULT_GENESIS_PATH = os.path.join(PYGETH_DIR, 'genesis.json')
 
 
 ALL_APIS = "admin,debug,eth,miner,net,personal,shh,txpool,web3"
 
 
 def construct_test_chain_kwargs(**overrides):
-    overrides.setdefault('genesis_path', DEFAULT_GENESIS_PATH)
     overrides.setdefault('unlock', '0')
     overrides.setdefault('password', DEFAULT_PASSWORD_PATH)
     overrides.setdefault('mine', True)
@@ -57,7 +55,6 @@ def construct_test_chain_kwargs(**overrides):
 
 def construct_popen_command(data_dir=None,
                             geth_executable="geth",
-                            genesis_path=None,
                             max_peers=None,
                             network_id=None,
                             no_discover=None,
@@ -95,9 +92,6 @@ def construct_popen_command(data_dir=None,
 
     if rpc_api is not None:
         command.extend(('--rpcapi', rpc_api))
-
-    if genesis_path is not None:
-        command.extend(('--genesis', genesis_path))
 
     if data_dir is not None:
         command.extend(('--datadir', data_dir))


### PR DESCRIPTION
### What was wrong?

The manner in which `--genesis` was being used is deprecated.

### How was it fixed?

Changed to using `geth init` to initialize the genesis file.

#### Cute Animal Picture

> put a cute animal picture here.

![cute-baby-animals-32](https://cloud.githubusercontent.com/assets/824194/16592220/db23eb9e-429c-11e6-9331-fae0ebd960e1.jpg)
