### PR TITLE
Fix test chains not having  available

### DIFF
--- a/geth/chain.py
+++ b/geth/chain.py
@@ -85,13 +85,21 @@ def write_genesis_file(genesis_file_path,
                        difficulty="0x400",
                        mixhash="0x0000000000000000000000000000000000000000000000000000000000000000",  # NOQA
                        coinbase="0x3333333333333333333333333333333333333333",
-                       alloc=None):
+                       alloc=None,
+                       config=None):
 
     if os.path.exists(genesis_file_path) and not overwrite:
         raise ValueError("Genesis file already present.  call with `overwrite=True` to overwrite this file")  # NOQA
 
     if alloc is None:
         alloc = {}
+
+    if config is None:
+        config = {
+            'homesteadBlock': 0,
+            'daoForkBlock': 0,
+            'daoForSupport': True,
+        }
 
     genesis_data = {
         "nonce": nonce,
@@ -103,6 +111,7 @@ def write_genesis_file(genesis_file_path,
         "mixhash": mixhash,
         "coinbase": coinbase,
         "alloc": alloc,
+        "config": config,
     }
 
     with open(genesis_file_path, 'w') as genesis_file:

--- a/geth/utils/proc.py
+++ b/geth/utils/proc.py
@@ -1,26 +1,40 @@
-import time
 import signal
 
 import gevent
 
 
-def wait_for_popen(proc, max_wait=5):
-    wait_till = time.time() + 5
-    while proc.poll() is None and time.time() < wait_till:
-        gevent.sleep(0.1)
+def wait_for_popen(proc, timeout=30):
+    try:
+        with gevent.Timeout(30):
+            while proc.poll() is None:
+                gevent.sleep(0.1)
+    except gevent.Timeout:
+        pass
 
 
 def kill_proc(proc):
     try:
         if proc.poll() is None:
-            proc.send_signal(signal.SIGINT)
-            wait_for_popen(proc, 5)
+            try:
+                proc.send_signal(signal.SIGINT)
+                wait_for_popen(proc, 30)
+            except KeyboardInterrupt:
+                print(
+                    "Trying to close geth process.  Press Ctrl+C 2 more times "
+                    "to force quit"
+                )
         if proc.poll() is None:
-            proc.terminate()
-            wait_for_popen(proc, 2)
+            try:
+                proc.terminate()
+                wait_for_popen(proc, 10)
+            except KeyboardInterrupt:
+                print(
+                    "Trying to close geth process.  Press Ctrl+C 1 more times "
+                    "to force quit"
+                )
         if proc.poll() is None:
             proc.kill()
-            wait_for_popen(proc, 1)
+            wait_for_popen(proc, 2)
     except KeyboardInterrupt:
         proc.kill()
 


### PR DESCRIPTION
### What was wrong?

The `DELEGATECALL` opcode isn't available until after the homestead hard fork block.  For test chains, this should be set to 0.

### How was it fixed?

Added new default config for the genesis file to configure both the homestead fork block and the dao fork block to be 0.

#### Cute Animal Picture

> put a cute animal picture here.

![e6cfb6b2c8d060ff25425573f81c673d](https://cloud.githubusercontent.com/assets/824194/17470689/8e3ca3a6-5cfb-11e6-9ebb-e7ab0dca5f70.jpg)
