### PR TITLE
use local geth ipc path when possible

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,8 @@
-import pytest
 import json
+
 import requests
+
+import pytest
 
 
 @pytest.fixture

--- a/geth/geth.py
+++ b/geth/geth.py
@@ -134,7 +134,12 @@ class BaseGethProcess(object):
 
     @property
     def ipc_path(self):
-        raise NotImplementedError("Must be implemented by subclasses")
+        return self.geth_kwargs.get(
+            'ipc_path',
+            os.path.abspath(os.path.expanduser(os.path.join(
+                self.data_dir, 'geth.ipc',
+            )))
+        )
 
     @property
     def is_ipc_ready(self):
@@ -189,15 +194,6 @@ class LiveGethProcess(BaseGethProcess):
     def data_dir(self):
         return get_live_data_dir()
 
-    @property
-    def ipc_path(self):
-        return self.geth_kwargs.get(
-            'ipc_path',
-            os.path.abspath(os.path.expanduser(os.path.join(
-                self.data_dir, 'geth.ipc',
-            ))),
-        )
-
 
 class TestnetGethProcess(BaseGethProcess):
     def __init__(self, geth_kwargs=None):
@@ -217,15 +213,6 @@ class TestnetGethProcess(BaseGethProcess):
     @property
     def data_dir(self):
         return get_testnet_data_dir()
-
-    @property
-    def ipc_path(self):
-        return self.geth_kwargs.get(
-            'ipc_path',
-            os.path.abspath(os.path.expanduser(os.path.join(
-                self.data_dir, 'geth.ipc',
-            )))
-        )
 
 
 class DevGethProcess(BaseGethProcess):

--- a/geth/geth.py
+++ b/geth/geth.py
@@ -134,12 +134,7 @@ class BaseGethProcess(object):
 
     @property
     def ipc_path(self):
-        return self.geth_kwargs.get(
-            'ipc_path',
-            os.path.abspath(os.path.expanduser(os.path.join(
-                get_live_data_dir(), 'geth.ipc',
-            ))),
-        )
+        raise NotImplementedError("Must be implemented by subclasses")
 
     @property
     def is_ipc_ready(self):
@@ -181,7 +176,10 @@ class BaseGethProcess(object):
 
 
 class LiveGethProcess(BaseGethProcess):
-    def __init__(self, geth_kwargs):
+    def __init__(self, geth_kwargs=None):
+        if geth_kwargs is None:
+            geth_kwargs = {}
+
         if 'data_dir' in geth_kwargs:
             raise ValueError("You cannot specify `data_dir` for a LiveGethProcess")
 
@@ -191,22 +189,43 @@ class LiveGethProcess(BaseGethProcess):
     def data_dir(self):
         return get_live_data_dir()
 
+    @property
+    def ipc_path(self):
+        return self.geth_kwargs.get(
+            'ipc_path',
+            os.path.abspath(os.path.expanduser(os.path.join(
+                self.data_dir, 'geth.ipc',
+            ))),
+        )
+
 
 class TestnetGethProcess(BaseGethProcess):
-    def __init__(self, geth_kwargs):
+    def __init__(self, geth_kwargs=None):
+        if geth_kwargs is None:
+            geth_kwargs = {}
+
         if 'data_dir' in geth_kwargs:
             raise ValueError("You cannot specify `data_dir` for a TestnetGethProces")
 
-        extra_kwargs = geth_kwargs.get('extra_kwargs', [])
-        extra_kwargs.append('--testnet')
+        suffix_kwargs = geth_kwargs.get('suffix_kwargs', [])
+        suffix_kwargs.append('--testnet')
 
-        geth_kwargs['extra_kwargs'] = extra_kwargs
+        geth_kwargs['suffix_kwargs'] = suffix_kwargs
 
         super(TestnetGethProcess, self).__init__(geth_kwargs)
 
     @property
     def data_dir(self):
         return get_testnet_data_dir()
+
+    @property
+    def ipc_path(self):
+        return self.geth_kwargs.get(
+            'ipc_path',
+            os.path.abspath(os.path.expanduser(os.path.join(
+                self.data_dir, 'geth.ipc',
+            )))
+        )
 
 
 class DevGethProcess(BaseGethProcess):

--- a/geth/geth.py
+++ b/geth/geth.py
@@ -227,7 +227,7 @@ class DevGethProcess(BaseGethProcess):
         )
 
         # ensure that an account is present
-        coinbase = ensure_account_exists(self.data_dir, **geth_kwargs)
+        coinbase = ensure_account_exists(**geth_kwargs)
 
         # ensure that the chain is initialized
         genesis_file_path = get_genesis_file_path(self.data_dir)
@@ -244,6 +244,6 @@ class DevGethProcess(BaseGethProcess):
                     (coinbase, {"balance": "1000000000000000000000000000000"}),  # 1 billion ether.
                 ]),
             }
-            initialize_chain(genesis_data, self.data_dir, **geth_kwargs)
+            initialize_chain(genesis_data, **geth_kwargs)
 
         super(DevGethProcess, self).__init__(geth_kwargs)

--- a/geth/geth.py
+++ b/geth/geth.py
@@ -220,8 +220,8 @@ class DevGethProcess(BaseGethProcess):
         if base_dir is None:
             base_dir = get_default_base_dir()
 
-        geth_kwargs = construct_test_chain_kwargs(**overrides)
         self.data_dir = get_chain_data_dir(base_dir, chain_name)
+        geth_kwargs = construct_test_chain_kwargs(data_dir=data_dir, **overrides)
 
         # ensure that an account is present
         coinbase = ensure_account_exists(self.data_dir, **geth_kwargs)

--- a/geth/geth.py
+++ b/geth/geth.py
@@ -221,7 +221,10 @@ class DevGethProcess(BaseGethProcess):
             base_dir = get_default_base_dir()
 
         self.data_dir = get_chain_data_dir(base_dir, chain_name)
-        geth_kwargs = construct_test_chain_kwargs(data_dir=data_dir, **overrides)
+        geth_kwargs = construct_test_chain_kwargs(
+            data_dir=self.data_dir,
+            **overrides
+        )
 
         # ensure that an account is present
         coinbase = ensure_account_exists(self.data_dir, **geth_kwargs)
@@ -242,7 +245,5 @@ class DevGethProcess(BaseGethProcess):
                 ]),
             }
             initialize_chain(genesis_data, self.data_dir, **geth_kwargs)
-
-        geth_kwargs['data_dir'] = self.data_dir
 
         super(DevGethProcess, self).__init__(geth_kwargs)

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -74,7 +74,7 @@ def construct_test_chain_kwargs(**overrides):
         # Otherwise default to a tempfile based ipc path.
         overrides.setdefault(
             'ipc_path',
-            os.path.join(tempfile.mkdtemp, 'geth.ipc'),
+            os.path.join(tempfile.mkdtemp(), 'geth.ipc'),
         )
 
     overrides.setdefault('ipc_path', tempfile.NamedTemporaryFile().name)

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -74,7 +74,7 @@ def construct_test_chain_kwargs(**overrides):
         # Otherwise default to a tempfile based ipc path.
         overrides.setdefault(
             'ipc_path',
-            os.path.join(tempfile.TemporaryDirectory().name, 'geth.ipc'),
+            os.path.join(tempfile.mkdtemp, 'geth.ipc'),
         )
 
     overrides.setdefault('ipc_path', tempfile.NamedTemporaryFile().name)

--- a/tests/running/test_running_mainnet_chain.py
+++ b/tests/running/test_running_mainnet_chain.py
@@ -1,0 +1,16 @@
+from geth.geth import LiveGethProcess
+
+
+def test_live_chain_with_no_overrides():
+    geth = LiveGethProcess()
+
+    geth.start()
+
+    geth.wait_for_ipc(30)
+
+    assert geth.is_running
+    assert geth.is_alive
+
+    geth.stop()
+
+    assert geth.is_stopped

--- a/tests/running/test_running_morden_chain.py
+++ b/tests/running/test_running_morden_chain.py
@@ -1,0 +1,21 @@
+from geth.geth import TestnetGethProcess
+from geth.mixins import LoggingMixin
+
+
+class LoggedTestnetGethProcess(LoggingMixin, TestnetGethProcess):
+    pass
+
+
+def test_testnet_chain_with_no_overrides():
+    geth = LoggedTestnetGethProcess()
+
+    geth.start()
+
+    geth.wait_for_ipc(30)
+
+    assert geth.is_running
+    assert geth.is_alive
+
+    geth.stop()
+
+    assert geth.is_stopped

--- a/tests/utility/test_constructing_test_chain_kwargs.py
+++ b/tests/utility/test_constructing_test_chain_kwargs.py
@@ -1,0 +1,44 @@
+import shutil
+import tempfile
+import contextlib
+import os
+
+from geth.wrapper import (
+    construct_test_chain_kwargs,
+    get_max_socket_path_length,
+)
+
+
+@contextlib.contextmanager
+def tempdir():
+    directory = tempfile.mkdtemp()
+
+    try:
+        yield directory
+    finally:
+        shutil.rmtree(directory)
+
+
+def test_short_data_directory_paths_use_local_geth_ipc_socket():
+    with tempdir() as data_dir:
+        expected_path = os.path.abspath(os.path.join(data_dir, 'geth.ipc'))
+        assert len(expected_path) < get_max_socket_path_length()
+        chain_kwargs = construct_test_chain_kwargs(data_dir=data_dir)
+
+        assert chain_kwargs['ipc_path'] == expected_path
+
+
+def test_long_data_directory_paths_use_tempfile_geth_ipc_socket():
+    with tempdir() as temp_directory:
+        data_dir = os.path.abspath(os.path.join(
+            temp_directory,
+            'this-path-is-longer-than-the-maximum-unix-socket-path-lengh',
+            'and-thus-the-underlying-function-should-not-use-it-for-the',
+            'geth-ipc-path',
+        ))
+        data_dir_ipc_path = os.path.abspath(os.path.join(data_dir, 'geth.ipc'))
+        assert len(data_dir_ipc_path) > get_max_socket_path_length()
+
+        chain_kwargs = construct_test_chain_kwargs(data_dir=data_dir)
+
+        assert chain_kwargs['ipc_path'] != data_dir_ipc_path


### PR DESCRIPTION
### What was wrong?

When setting up a test chain, the ipc_path was always being set to a tempfile.  This was originally done to ensure that the path length didn't exceed the unix socket max path lenght.  In many cases, the `data-dir/geth.ipc` path is sufficiently short to fit within the maximum unix socket path lenght.

### How was it fixed?

Changed how this value was computed to try and use the data-dir as the base path for the socket.

This also ended up containing some fixes for the `Testnet` and `Live` geth processes

#### Cute Animal Picture

> put a cute animal picture here.

![dd1f834d971941358d7b9bd463c442c9](https://cloud.githubusercontent.com/assets/824194/17601031/708f372c-5fc3-11e6-9252-135ceb5ba2d0.jpg)
