### PR TITLE
Add the 'ws' api to the list of all apis

### DIFF
--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -23,7 +23,7 @@ PYGETH_DIR = os.path.abspath(os.path.dirname(__file__))
 DEFAULT_PASSWORD_PATH = os.path.join(PYGETH_DIR, 'default_blockchain_password')
 
 
-ALL_APIS = "admin,debug,eth,miner,net,personal,shh,txpool,web3"
+ALL_APIS = "admin,debug,eth,miner,net,personal,shh,txpool,web3,ws"
 
 
 def get_max_socket_path_length():
@@ -77,7 +77,6 @@ def construct_test_chain_kwargs(**overrides):
             os.path.join(tempfile.mkdtemp(), 'geth.ipc'),
         )
 
-    overrides.setdefault('ipc_path', tempfile.NamedTemporaryFile().name)
     overrides.setdefault('ipc_api', ALL_APIS)
 
     overrides.setdefault('verbosity', '5')


### PR DESCRIPTION
### What was wrong?

The Websocket API was missing from the defaults when running a dev chain.

### How was it fixed?

Add `ws` to the list of `ALL_APIS`

#### Cute Animal Picture

> put a cute animal picture here.

![dog_shaming_2724601b](https://cloud.githubusercontent.com/assets/824194/17639301/26c31d8e-60ae-11e6-857e-093c447f5b73.jpg)
