### PR TITLE
Allow configuration of chain genesis data through constructor

### DIFF
--- a/geth/chain.py
+++ b/geth/chain.py
@@ -81,7 +81,7 @@ def write_genesis_file(genesis_file_path,
                        timestamp="0x0",
                        parentHash="0x0000000000000000000000000000000000000000000000000000000000000000",  # NOQA
                        extraData="0x686f727365",
-                       gasLimit="0x2fefd8",
+                       gasLimit="0x47d5cc",
                        difficulty="0x400",
                        mixhash="0x0000000000000000000000000000000000000000000000000000000000000000",  # NOQA
                        coinbase="0x3333333333333333333333333333333333333333",

--- a/geth/geth.py
+++ b/geth/geth.py
@@ -220,9 +220,12 @@ class TestnetGethProcess(BaseGethProcess):
 
 
 class DevGethProcess(BaseGethProcess):
-    def __init__(self, chain_name, base_dir=None, overrides=None):
+    def __init__(self, chain_name, base_dir=None, overrides=None, genesis_data=None):
         if overrides is None:
             overrides = {}
+
+        if genesis_data is None:
+            genesis_data = {}
 
         if 'data_dir' in overrides:
             raise ValueError("You cannot specify `data_dir` for a DevGethProcess")
@@ -249,11 +252,12 @@ class DevGethProcess(BaseGethProcess):
         ))
 
         if needs_init:
-            genesis_data = {
-                'alloc': dict([
+            genesis_data.setdefault(
+                'alloc',
+                dict([
                     (coinbase, {"balance": "1000000000000000000000000000000"}),  # 1 billion ether.
-                ]),
-            }
+                ])
+            )
             initialize_chain(genesis_data, **geth_kwargs)
 
         super(DevGethProcess, self).__init__(geth_kwargs)


### PR DESCRIPTION
### What was wrong?

No ability to control genesis parameters when instantiating a new `DevGethProcess` chain.

### How was it fixed?

Added a new parameter that allows passing in genesis data via the constructor.

#### Cute Animal Picture

> put a cute animal picture here.

![good-karma-rope-toy](https://cloud.githubusercontent.com/assets/824194/17829086/add56a0a-665f-11e6-8905-f5a12db7bad7.jpg)
