### PR TITLE
Enabled shh for DevGethProcess,added flake8 in requirements-dev.txt a…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help:
 	@echo "clean-pyc - remove Python file artifacts"
 	@echo "lint - check style with flake8"
 	@echo "test - run tests quickly with the default Python"
-	@echo "testall - run tests on every Python version with tox"
+	@echo "test-all - run tests on every Python version with tox"
 	@echo "release - package and upload a release"
 	@echo "sdist - package"
 

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -89,7 +89,8 @@ def construct_test_chain_kwargs(**overrides):
     overrides.setdefault('ipc_api', ALL_APIS)
 
     overrides.setdefault('verbosity', '5')
-    overrides.setdefault('shh', True)
+    if 'shh' in overrides:
+        overrides.setdefault('shh', overrides['shh'])
     return overrides
 
 

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -208,14 +208,14 @@ def construct_popen_command(data_dir=None,
     if autodag:
         command.append('--autodag')
 
+    if shh:
+        command.append('--shh')
+
     if suffix_kwargs:
         command.extend(suffix_kwargs)
 
     if suffix_args:
         command.extend(suffix_args)
-
-    if shh:
-        command.extend('--shh')
 
     return command
 

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -89,6 +89,7 @@ def construct_test_chain_kwargs(**overrides):
     overrides.setdefault('ipc_api', ALL_APIS)
 
     overrides.setdefault('verbosity', '5')
+    overrides.setdefault('shh', True)
     return overrides
 
 
@@ -118,7 +119,8 @@ def construct_popen_command(data_dir=None,
                             ws_port=None,
                             ws_api=None,
                             suffix_args=None,
-                            suffix_kwargs=None):
+                            suffix_kwargs=None,
+                            shh=None):
     command = []
 
     if nice and is_nice_available():
@@ -210,6 +212,9 @@ def construct_popen_command(data_dir=None,
 
     if suffix_args:
         command.extend(suffix_args)
+
+    if shh:
+        command.extend('--shh')
 
     return command
 

--- a/geth/wrapper.py
+++ b/geth/wrapper.py
@@ -89,8 +89,7 @@ def construct_test_chain_kwargs(**overrides):
     overrides.setdefault('ipc_api', ALL_APIS)
 
     overrides.setdefault('verbosity', '5')
-    if 'shh' in overrides:
-        overrides.setdefault('shh', overrides['shh'])
+
     return overrides
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest>=2.9.2
 tox>=2.3.1
 requests==2.10.0
 flaky==3.2.0
+flake8==3.0.4


### PR DESCRIPTION
### What was wrong?
Shh is not enabled in geth even if it is explicitly mentioned via **--rpcapi** or **--ipcapi**


### How was it fixed?
Added an option to enable Shh while constructing test chain kwargs. (in **construct_test_chain_kwargs**)



#### Cute Animal Picture
Next time for sure.

> put a cute animal picture here.