### PR TITLE
expand test suite and add installation instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,43 +8,42 @@ cache:
   directories:
     - $HOME/.ethash
 env:
+  global:
+    - GETH_BASE_INSTALL_PATH=$TRAVIS_BUILD_DIR
+    - GOROOT=$HOME/go
   matrix:
+    # installation
+    - TOX_POSARGS="-e py27-installation"
+    - TOX_POSARGS="-e py34-installation"
+    - TOX_POSARGS="-e py35-installation"
     # geth 1.5.6
-    - TOX_ENV=py27-stdlib GETH_VERSION=1.5.6
-    - TOX_ENV=py34-stdlib GETH_VERSION=1.5.6
-    - TOX_ENV=py35-stdlib GETH_VERSION=1.5.6
+    - TOX_POSARGS="-e py27-stdlib -e py34-stdlib -e py35-stdlib -e py27-gevent -e py34-gevent -e py35-gevent" GETH_VERSION=v1.5.6
     # geth 1.5.7
-    - TOX_ENV=py27-stdlib GETH_VERSION=1.5.7
-    - TOX_ENV=py34-stdlib GETH_VERSION=1.5.7
-    - TOX_ENV=py35-stdlib GETH_VERSION=1.5.7
+    - TOX_POSARGS="-e py27-stdlib -e py34-stdlib -e py35-stdlib -e py27-gevent -e py34-gevent -e py35-gevent" GETH_VERSION=v1.5.7
     # geth 1.5.8
-    - TOX_ENV=py27-stdlib GETH_VERSION=1.5.8
-    - TOX_ENV=py34-stdlib GETH_VERSION=1.5.8
-    - TOX_ENV=py35-stdlib GETH_VERSION=1.5.8
+    - TOX_POSARGS="-e py27-stdlib -e py34-stdlib -e py35-stdlib -e py27-gevent -e py34-gevent -e py35-gevent" GETH_VERSION=v1.5.8
     # geth 1.5.9
-    - TOX_ENV=py27-stdlib GETH_VERSION=1.5.9
-    - TOX_ENV=py34-stdlib GETH_VERSION=1.5.9
-    - TOX_ENV=py35-stdlib GETH_VERSION=1.5.9
+    - TOX_POSARGS="-e py27-stdlib -e py34-stdlib -e py35-stdlib -e py27-gevent -e py34-gevent -e py35-gevent" GETH_VERSION=v1.5.9
     # geth 1.6.0
-    - TOX_ENV=py27-stdlib GETH_VERSION=1.6.0
-    - TOX_ENV=py34-stdlib GETH_VERSION=1.6.0
-    - TOX_ENV=py35-stdlib GETH_VERSION=1.6.0
+    - TOX_POSARGS="-e py27-stdlib -e py34-stdlib -e py35-stdlib -e py27-gevent -e py34-gevent -e py35-gevent" GETH_VERSION=v1.6.0
     # flake8
-    - TOX_ENV=flake8
+    - TOX_POSARGS="-e flake8"
 before_install:
-  - if [ -n "$GETH_VERSION" ]; then travis_retry sudo add-apt-repository -y ppa:gophers/archive; fi
-  - if [ -n "$GETH_VERSION" ]; then travis_retry sudo apt-get update; fi
-  - if [ -n "$GETH_VERSION" ]; then export GETH_BINARY="$TRAVIS_BUILD_DIR/geth-versions/geth-$GETH_VERSION/go-ethereum-$GETH_VERSION/build/bin/geth"; fi
+  - travis_retry sudo add-apt-repository -y ppa:gophers/archive
+  - travis_retry sudo apt-get update
+  - mkdir -p $HOME/.ethash
 install:
-  - if [ -n "$GETH_VERSION" ]; then travis_retry sudo apt-get install -y golang-1.7 build-essential; fi
+  - travis_retry sudo apt-get install -y golang-1.7 build-essential
   - travis_retry pip install setuptools --upgrade
   - travis_retry pip install tox
-  - if [ -n "$GETH_VERSION" ]; then /.$TRAVIS_BUILD_DIR/bin/install_geth.sh; fi
-  - mkdir -p $HOME/.ethash
+  - pip install -e .
 before_script:
-  - if [ -n "$GETH_VERSION" ]; then /.$TRAVIS_BUILD_DIR/geth-versions/geth-$GETH_VERSION/go-ethereum-$GETH_VERSION/build/bin/geth version; fi
-  - if [ -n "$GETH_VERSION" ]; then /.$TRAVIS_BUILD_DIR/geth-versions/geth-$GETH_VERSION/go-ethereum-$GETH_VERSION/build/bin/geth makedag 0 $HOME/.ethash; fi
+  - export GOROOT=/usr/lib/go-1.7
+  - if [ -n "$GETH_VERSION" ]; then python3 -m geth.install $GETH_VERSION; fi
+  - if [ -n "$GETH_VERSION" ]; then export GETH_BINARY="$GETH_BASE_INSTALL_PATH/geth-$GETH_VERSION/bin/geth"; fi
+  - if [ -n "$GETH_VERSION" ]; then $GETH_BINARY version; fi
+  - if [ -n "$GETH_VERSION" ]; then $GETH_BINARY makedag 0 $HOME/.ethash; fi
 script:
-  - tox -e $TOX_ENV
+  - tox $TOX_POSARGS
 after_script:
-  - cat .tox/$TOX_ENV/log/*.log
+  - cat .tox/$TOX_POSARGS/log/*.log

--- a/README.md
+++ b/README.md
@@ -128,7 +128,44 @@ True
 > The DAG functionality currently only applies to the DAG for epoch 0.
 
 
-# Aboutn `DevGethProcess`
+# Installing specific versions of `geth`
+
+> This feature is experimental and subject to breaking changes.
+
+Any of the following versions of `geth` can be installed using `py-geth` on the
+listed platforms.
+
+* `v1.5.6` (linux/osx)
+* `v1.5.7` (linux/osx)
+* `v1.5.8` (linux/osx)
+* `v1.5.9` (linux/osx)
+* `v1.6.0` (linux/osx)
+* `v1.6.1` (linux/osx)
+* `v1.6.2` (linux/osx)
+* `v1.6.3` (linux/osx)
+* `v1.6.4` (linux/osx)
+* `v1.6.5` (linux/osx)
+* `v1.6.6` (linux/osx)
+
+Installation can be done via the command line:
+
+```bash
+$ python -m geth.install v0.4.12
+```
+
+Or from python using the `install_geth` function.
+
+```python
+>>> from geth import install_geth
+>>> install_geth('v1.6.6')
+```
+
+The installed binary can be found in the `$HOME/.py-geth` directory, under your
+home directory.  The `v1.6.12` binary would be located at
+`$HOME/.py-geth/geth-v0.4.12/bin/geth`.
+
+
+# About `DevGethProcess`
 
 The `DevGethProcess` is designed to facilitate testing.  In that regard, it is
 preconfigured as follows.

--- a/geth/__init__.py
+++ b/geth/__init__.py
@@ -4,12 +4,20 @@ import pkg_resources
 __version__ = pkg_resources.get_distribution("py-geth").version
 
 
-from .geth import (  # NOQA
+from .main import (  # noqa: F401
+    get_geth_version,
+)
+from .install import (  # noqa: F401
+    install_geth,
+)
+from .process import (  # noqa: F401
     LiveGethProcess,
+    MainnetGethProcess,
+    RopstenGethProcess,
     TestnetGethProcess,
     DevGethProcess,
 )
-from .mixins import (  # NOQA
+from .mixins import (  # noqa: F401
     InterceptedStreamsMixin,
     LoggingMixin,
 )

--- a/geth/exceptions.py
+++ b/geth/exceptions.py
@@ -1,0 +1,38 @@
+import textwrap
+
+from .utils.encoding import force_text
+
+
+def force_text_maybe(value):
+    if value is not None:
+        return force_text(value, 'utf8')
+
+
+DEFAULT_MESSAGE = "An error occurred during execution"
+
+
+class GethError(Exception):
+    message = DEFAULT_MESSAGE
+
+    def __init__(self, command, return_code, stdin_data, stdout_data, stderr_data, message=None):
+        if message is not None:
+            self.message = message
+        self.command = command
+        self.return_code = return_code
+        self.stdin_data = force_text_maybe(stdin_data)
+        self.stderr_data = force_text_maybe(stderr_data)
+        self.stdout_data = force_text_maybe(stdout_data)
+
+    def __str__(self):
+        return textwrap.dedent(("""
+        {s.message}
+        > command: `{command}`
+        > return code: `{s.return_code}`
+        > stderr:
+        {s.stdout_data}
+        > stdout:
+        {s.stderr_data}
+        """).format(
+            s=self,
+            command=' '.join(self.command),
+        )).strip()

--- a/geth/install.py
+++ b/geth/install.py
@@ -1,0 +1,361 @@
+"""
+Install geth
+"""
+import functools
+import os
+import stat
+import subprocess
+import sys
+import contextlib
+
+import tarfile
+
+
+V1_5_6 = 'v1.5.6'
+V1_5_7 = 'v1.5.7'
+V1_5_8 = 'v1.5.8'
+V1_5_9 = 'v1.5.9'
+V1_6_0 = 'v1.6.0'
+V1_6_1 = 'v1.6.1'
+V1_6_2 = 'v1.6.2'
+V1_6_3 = 'v1.6.3'
+V1_6_4 = 'v1.6.4'
+V1_6_5 = 'v1.6.5'
+V1_6_6 = 'v1.6.6'
+
+
+LINUX = 'linux'
+OSX = 'darwin'
+WINDOWS = 'win32'
+
+
+#
+# System utilities.
+#
+@contextlib.contextmanager
+def chdir(path):
+    original_path = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(original_path)
+
+
+def get_platform():
+    if sys.platform.startswith('linux'):
+        return LINUX
+    elif sys.platform == OSX:
+        return OSX
+    elif sys.platform == WINDOWS:
+        return WINDOWS
+    else:
+        raise KeyError("Unknown platform: {0}".format(sys.platform))
+
+
+def is_executable_available(program):
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath = os.path.dirname(program)
+    if fpath:
+        if is_exe(program):
+            return True
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return True
+
+    return False
+
+
+def ensure_path_exists(dir_path):
+    """
+    Make sure that a path exists
+    """
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+        return True
+    return False
+
+
+def ensure_parent_dir_exists(path):
+    ensure_path_exists(os.path.dirname(path))
+
+
+def check_subprocess_call(command, message=None, stderr=subprocess.STDOUT, **proc_kwargs):
+    if message:
+        print(message)
+    print("Executing: {0}".format(" ".join(command)))
+
+    return subprocess.check_call(
+        command,
+        stderr=subprocess.STDOUT,
+        **proc_kwargs
+    )
+
+
+def check_subprocess_output(command, message=None, stderr=subprocess.STDOUT, **proc_kwargs):
+    if message:
+        print(message)
+    print("Executing: {0}".format(" ".join(command)))
+
+    return subprocess.check_output(
+        command,
+        stderr=subprocess.STDOUT,
+        **proc_kwargs
+    )
+
+
+def chmod_plus_x(executable_path):
+    current_st = os.stat(executable_path)
+    os.chmod(executable_path, current_st.st_mode | stat.S_IEXEC)
+
+
+def get_go_executable_path():
+    return os.environ.get('GO_BINARY', 'go')
+
+
+def is_go_available():
+    return is_executable_available(get_go_executable_path())
+
+
+#
+#  Installation filesystem path utilities
+#
+def get_base_install_path(identifier):
+    if 'GETH_BASE_INSTALL_PATH' in os.environ:
+        return os.path.join(
+            os.environ['GETH_BASE_INSTALL_PATH'],
+            'geth-{0}'.format(identifier),
+        )
+    else:
+        return os.path.expanduser(os.path.join(
+            '~',
+            '.py-geth',
+            'geth-{0}'.format(identifier),
+        ))
+
+
+def get_source_code_archive_path(identifier):
+    return os.path.join(
+        get_base_install_path(identifier),
+        'release.tar.gz',
+    )
+
+
+def get_source_code_extract_path(identifier):
+    return os.path.join(
+        get_base_install_path(identifier),
+        'source',
+    )
+
+
+def get_source_code_path(identifier):
+    return os.path.join(
+        get_base_install_path(identifier),
+        'source',
+        'go-ethereum-{0}'.format(identifier.lstrip('v')),
+    )
+
+
+def get_build_path(identifier):
+    source_code_path = get_source_code_path(identifier)
+    return os.path.join(
+        source_code_path,
+        'build',
+    )
+
+
+def get_built_executable_path(identifier):
+    build_path = get_build_path(identifier)
+    return os.path.join(
+        build_path,
+        'bin',
+        'geth',
+    )
+
+
+def get_executable_path(identifier):
+    base_install_path = get_base_install_path(identifier)
+    return os.path.join(
+        base_install_path,
+        'bin',
+        'geth',
+    )
+
+
+#
+# Installation primitives.
+#
+DOWNLOAD_SOURCE_CODE_URI_TEMPLATE = "https://github.com/ethereum/go-ethereum/archive/{0}.tar.gz"  # noqa: E501
+
+
+def download_source_code_release(identifier):
+    download_uri = DOWNLOAD_SOURCE_CODE_URI_TEMPLATE.format(identifier)
+    source_code_archive_path = get_source_code_archive_path(identifier)
+
+    ensure_parent_dir_exists(source_code_archive_path)
+
+    command = [
+        "wget", download_uri,
+        '-c',  # resume previously incomplete download.
+        '-O', source_code_archive_path,
+    ]
+
+    return check_subprocess_call(
+        command,
+        message="Downloading source code release from {0}".format(download_uri),
+    )
+
+
+def extract_source_code_release(identifier):
+    source_code_archive_path = get_source_code_archive_path(identifier)
+
+    source_code_extract_path = get_source_code_extract_path(identifier)
+    ensure_path_exists(source_code_extract_path)
+
+    print("Extracting archive: {0} -> {1}".format(
+        source_code_archive_path,
+        source_code_extract_path,
+    ))
+
+    with tarfile.open(source_code_archive_path, 'r:gz') as archive_file:
+        archive_file.extractall(source_code_extract_path)
+
+
+def build_from_source_code(identifier):
+    if not is_go_available():
+        raise OSError(
+            "The `go` runtime was not found but is required to build geth.  If "
+            "the `go` executable is not in your $PATH you can specify the path "
+            "using the environment variable GO_BINARY to specify the path."
+        )
+    source_code_path = get_source_code_path(identifier)
+
+    with chdir(source_code_path):
+        make_command = ["make", "geth"]
+
+        check_subprocess_call(
+            make_command,
+            message="Building `geth` binary",
+        )
+
+    built_executable_path = get_built_executable_path(identifier)
+    if not os.path.exists(built_executable_path):
+        raise OSError(
+            "Built executable not found in expected location: "
+            "{0}".format(built_executable_path)
+        )
+    print("Making built binary executable: chmod +x {0}".format(built_executable_path))
+    chmod_plus_x(built_executable_path)
+
+    executable_path = get_executable_path(identifier)
+    ensure_parent_dir_exists(executable_path)
+    if os.path.exists(executable_path):
+        if os.path.islink(executable_path):
+            os.remove(executable_path)
+        else:
+            raise OSError("Non-symlink file already present at `{0}`".format(executable_path))
+    os.symlink(built_executable_path, executable_path)
+    chmod_plus_x(executable_path)
+
+
+def install_from_source_code_release(identifier):
+    download_source_code_release(identifier)
+    extract_source_code_release(identifier)
+    build_from_source_code(identifier)
+
+    executable_path = get_executable_path(identifier)
+    assert os.path.exists(executable_path), "Executable not found @".format(executable_path)
+
+    check_version_command = [executable_path, 'version']
+
+    version_output = check_subprocess_output(
+        check_version_command,
+        message="Checking installed executable version @ {0}".format(executable_path),
+    )
+
+    print("geth successfully installed at: {0}\n\n{1}\n\n".format(
+        executable_path,
+        version_output,
+    ))
+
+
+install_v1_5_6 = functools.partial(install_from_source_code_release, V1_5_6)
+install_v1_5_7 = functools.partial(install_from_source_code_release, V1_5_7)
+install_v1_5_8 = functools.partial(install_from_source_code_release, V1_5_8)
+install_v1_5_9 = functools.partial(install_from_source_code_release, V1_5_9)
+install_v1_6_0 = functools.partial(install_from_source_code_release, V1_6_0)
+install_v1_6_1 = functools.partial(install_from_source_code_release, V1_6_1)
+install_v1_6_2 = functools.partial(install_from_source_code_release, V1_6_2)
+install_v1_6_3 = functools.partial(install_from_source_code_release, V1_6_3)
+install_v1_6_4 = functools.partial(install_from_source_code_release, V1_6_4)
+install_v1_6_5 = functools.partial(install_from_source_code_release, V1_6_5)
+install_v1_6_6 = functools.partial(install_from_source_code_release, V1_6_6)
+
+
+INSTALL_FUNCTIONS = {
+    LINUX: {
+        V1_5_6: install_v1_5_6,
+        V1_5_7: install_v1_5_7,
+        V1_5_8: install_v1_5_8,
+        V1_5_9: install_v1_5_9,
+        V1_6_0: install_v1_6_0,
+        V1_6_1: install_v1_6_1,
+        V1_6_2: install_v1_6_2,
+        V1_6_3: install_v1_6_3,
+        V1_6_4: install_v1_6_4,
+        V1_6_5: install_v1_6_5,
+        V1_6_6: install_v1_6_6,
+    },
+    OSX: {
+        V1_5_6: install_v1_5_6,
+        V1_5_7: install_v1_5_7,
+        V1_5_8: install_v1_5_8,
+        V1_5_9: install_v1_5_9,
+        V1_6_0: install_v1_6_0,
+        V1_6_1: install_v1_6_1,
+        V1_6_2: install_v1_6_2,
+        V1_6_3: install_v1_6_3,
+        V1_6_4: install_v1_6_4,
+        V1_6_5: install_v1_6_5,
+        V1_6_6: install_v1_6_6,
+    }
+}
+
+
+def install_geth(identifier, platform=None):
+    if platform is None:
+        platform = sys.platform
+
+    if platform not in INSTALL_FUNCTIONS:
+        raise ValueError(
+            "Installation of go-ethereum is not supported on your platform ({0}). "
+            "Supported platforms are: {1}".format(
+                platform,
+                ', '.join(sorted(INSTALL_FUNCTIONS.keys())),
+            )
+        )
+    elif identifier not in INSTALL_FUNCTIONS[platform]:
+        raise ValueError(
+            "Installation of geth=={0} is not supported.  Must be one of {1}".format(
+                identifier,
+                ', '.join(sorted(INSTALL_FUNCTIONS[platform].keys())),
+            )
+        )
+
+    install_fn = INSTALL_FUNCTIONS[platform][identifier]
+    install_fn()
+
+
+if __name__ == "__main__":
+    try:
+        identifier = sys.argv[1]
+    except IndexError:
+        print("Invocation error.  Should be invoked as `python -m geth.install <release-tag>`")
+        sys.exit(1)
+
+    install_geth(identifier)

--- a/geth/main.py
+++ b/geth/main.py
@@ -1,0 +1,35 @@
+import re
+
+import semantic_version
+
+from .utils.encoding import (
+    force_text,
+)
+from .wrapper import (  # noqa: E402
+    geth_wrapper,
+)
+
+
+def get_geth_version_info_string(**geth_kwargs):
+    if 'suffix_args' in geth_kwargs:
+        raise TypeError(
+            "The `get_geth_version` function cannot be called with the "
+            "`suffix_args` parameter"
+        )
+    geth_kwargs['suffix_args'] = ['version']
+    stdoutdata, stderrdata, command, proc = geth_wrapper(**geth_kwargs)
+    return stdoutdata
+
+
+VERSION_REGEX = r'Version: (.*)\n'
+
+
+def get_geth_version(**geth_kwargs):
+    version_info_string = get_geth_version_info_string(**geth_kwargs)
+    version_match = re.search(VERSION_REGEX, force_text(version_info_string, 'utf8'))
+    if not version_match:
+        raise ValueError(
+            "Did not match version string in geth output:\n{0}".format(version_info_string)
+        )
+    version_string = version_match.groups()[0]
+    return semantic_version.Version(version_string)

--- a/geth/process.py
+++ b/geth/process.py
@@ -1,6 +1,7 @@
 import os
 import random
 import logging
+import warnings
 
 try:
     from urllib.request import (
@@ -190,19 +191,28 @@ class BaseGethProcess(object):
                 _timeout.check()
 
 
-class LiveGethProcess(BaseGethProcess):
+class MainnetGethProcess(BaseGethProcess):
     def __init__(self, geth_kwargs=None):
         if geth_kwargs is None:
             geth_kwargs = {}
 
         if 'data_dir' in geth_kwargs:
-            raise ValueError("You cannot specify `data_dir` for a LiveGethProcess")
+            raise ValueError("You cannot specify `data_dir` for a MainnetGethProcess")
 
-        super(LiveGethProcess, self).__init__(geth_kwargs)
+        super(MainnetGethProcess, self).__init__(geth_kwargs)
 
     @property
     def data_dir(self):
         return get_live_data_dir()
+
+
+class LiveGethProcess(MainnetGethProcess):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(DeprecationWarning(
+            "The `LiveGethProcess` has been renamed to `MainnetGethProcess`. "
+            "The `LiveGethProcess` alias will be removed in subsequent releases"
+        ))
+        super(LiveGethProcess, self).__init__(*args, **kwargs)
 
 
 class RopstenGethProcess(BaseGethProcess):
@@ -237,6 +247,9 @@ class TestnetGethProcess(RopstenGethProcess):
 
 
 class DevGethProcess(BaseGethProcess):
+    """
+    A local private chain for development.
+    """
     def __init__(self, chain_name, base_dir=None, overrides=None, genesis_data=None):
         if overrides is None:
             overrides = {}

--- a/geth/utils/encoding.py
+++ b/geth/utils/encoding.py
@@ -1,3 +1,4 @@
+import codecs
 import sys
 
 
@@ -23,30 +24,22 @@ def is_string(value):
     return isinstance(value, string_types)
 
 
-if sys.version_info.major == 2:
-    def force_bytes(value):
-        if is_binary(value):
-            return str(value)
-        elif is_text(value):
-            return value.encode('latin1')
-        else:
-            raise TypeError("Unsupported type: {0}".format(type(value)))
+def force_bytes(value, encoding='iso-8859-1'):
+    if is_binary(value):
+        return bytes(value)
+    elif is_text(value):
+        return codecs.encode(value, encoding)
+    else:
+        raise TypeError("Unsupported type: {0}".format(type(value)))
 
-    def force_text(value):
-        if is_text(value):
-            return value
-        elif is_binary(value):
-            return unicode(force_bytes(value), 'latin1')  # NOQA
-        else:
-            raise TypeError("Unsupported type: {0}".format(type(value)))
-else:
-    def force_text(value):
-        if isinstance(value, text_types):
-            return value
-        elif isinstance(value, binary_types):
-            return str(value, 'latin1')
-        else:
-            raise TypeError("Unsupported type: {0}".format(type(value)))
+
+def force_text(value, encoding='iso-8859-1'):
+    if is_text(value):
+        return value
+    elif is_binary(value):
+        return codecs.decode(value, encoding)
+    else:
+        raise TypeError("Unsupported type: {0}".format(type(value)))
 
 
 def force_obj_to_text(obj):

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setup(
     url='https://github.com/pipermerriam/py-geth',
     include_package_data=True,
     py_modules=['geth'],
+    install_requires=[
+        "semantic-version>=2.6.0",
+    ],
     extras_require={
         'gevent': [
             "gevent>=1.1.1,!=1.2.0",

--- a/tests/installation/test_geth_installation.py
+++ b/tests/installation/test_geth_installation.py
@@ -1,0 +1,55 @@
+import os
+
+import pytest
+
+import semantic_version
+
+from geth import (
+    get_geth_version,
+)
+from geth.install import (
+    INSTALL_FUNCTIONS,
+    get_platform,
+    install_geth,
+    get_executable_path,
+)
+
+
+INSTALLATION_TEST_PARAMS = tuple(
+    (platform, version)
+    for platform, platform_install_functions in INSTALL_FUNCTIONS.items()
+    for version in platform_install_functions.keys()
+)
+
+
+@pytest.mark.skipif(
+    'GETH_RUN_INSTALL_TESTS' not in os.environ,
+    reason=(
+        "Installation tests will not run unless `GETH_RUN_INSTALL_TESTS` "
+        "environment variable is set"
+    ),
+)
+@pytest.mark.parametrize(
+    "platform,version",
+    INSTALLATION_TEST_PARAMS,
+)
+def test_geth_installation_as_function_call(monkeypatch, tmpdir, platform, version):
+    if get_platform() != platform:
+        pytest.skip("Wront platform for install script")
+
+    base_install_path = str(tmpdir.mkdir("temporary-dir"))
+    monkeypatch.setenv('GETH_BASE_INSTALL_PATH', base_install_path)
+
+    # sanity check that it's not already installed.
+    executable_path = get_executable_path(version)
+    assert not os.path.exists(executable_path)
+
+    install_geth(identifier=version, platform=platform)
+
+    assert os.path.exists(executable_path)
+    monkeypatch.setenv('GETH_BINARY', executable_path)
+
+    actual_version = get_geth_version()
+    expected_version = semantic_version.Spec(version.lstrip('v'))
+
+    assert actual_version in expected_version

--- a/tests/running/test_running_dev_chain.py
+++ b/tests/running/test_running_dev_chain.py
@@ -1,4 +1,4 @@
-from geth.geth import DevGethProcess
+from geth import DevGethProcess
 
 
 def test_with_no_overrides(base_dir):

--- a/tests/running/test_running_mainnet_chain.py
+++ b/tests/running/test_running_mainnet_chain.py
@@ -1,9 +1,9 @@
-from geth.geth import LiveGethProcess
+from geth import MainnetGethProcess
 from geth.mixins import LoggingMixin
 from geth.utils.networking import get_open_port
 
 
-class LoggedMainnetGethProcess(LoggingMixin, LiveGethProcess):
+class LoggedMainnetGethProcess(LoggingMixin, MainnetGethProcess):
     pass
 
 

--- a/tests/running/test_running_ropsten_chain.py
+++ b/tests/running/test_running_ropsten_chain.py
@@ -1,14 +1,14 @@
-from geth.geth import TestnetGethProcess
+from geth import RopstenGethProcess
 from geth.mixins import LoggingMixin
 from geth.utils.networking import get_open_port
 
 
-class LoggedTestnetGethProcess(LoggingMixin, TestnetGethProcess):
+class LoggedRopstenGethProcess(LoggingMixin, RopstenGethProcess):
     pass
 
 
 def test_testnet_chain_with_no_overrides():
-    geth = LoggedTestnetGethProcess(geth_kwargs={'port': get_open_port()})
+    geth = LoggedRopstenGethProcess(geth_kwargs={'port': get_open_port()})
 
     geth.start()
 

--- a/tests/running/test_running_with_logging.py
+++ b/tests/running/test_running_with_logging.py
@@ -1,4 +1,4 @@
-from geth.geth import DevGethProcess
+from geth import DevGethProcess
 from geth.mixins import LoggingMixin
 
 

--- a/tests/running/test_use_as_a_context_manager.py
+++ b/tests/running/test_use_as_a_context_manager.py
@@ -1,4 +1,4 @@
-from geth.geth import DevGethProcess
+from geth import DevGethProcess
 
 
 def test_using_as_a_context_manager(base_dir):

--- a/tests/utility/test_geth_version.py
+++ b/tests/utility/test_geth_version.py
@@ -1,0 +1,9 @@
+from geth import get_geth_version
+
+import semantic_version
+
+
+def test_get_geth_version():
+    version = get_geth_version()
+
+    assert isinstance(version, semantic_version.Version)

--- a/tests/waiting/test_waiting_for_ipc_socket.py
+++ b/tests/waiting/test_waiting_for_ipc_socket.py
@@ -1,7 +1,8 @@
 import pytest
+
 from flaky import flaky
 
-from geth.geth import DevGethProcess
+from geth import DevGethProcess
 from geth.utils.compat import (
     Timeout,
 )

--- a/tests/waiting/test_waiting_for_rpc_connection.py
+++ b/tests/waiting/test_waiting_for_rpc_connection.py
@@ -1,7 +1,8 @@
 import pytest
+
 from flaky import flaky
 
-from geth.geth import DevGethProcess
+from geth import DevGethProcess
 from geth.utils.compat import (
     Timeout,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist=
     py{27,34,35}-{gevent,stdlib},
+    py{27,34,35}-installation
     flake8
 
 [flake8]
@@ -8,12 +9,18 @@ max-line-length= 100
 exclude= tests/*
 
 [testenv]
-commands=py.test {posargs:tests}
+commands=
+    {gevent,stdlib}: py.test {posargs:tests}
+    py{27,34,35}-installation: py.test {posargs:-s tests/installation}
 passenv =
+    GETH_BASE_INSTALL_PATH
     GETH_BINARY
     TRAVIS_BUILD_DIR
+    GOROOT
+    GOPATH
 setenv =
     gevent: GETH_THREADING_BACKEND=gevent
+    py{27,34,35}-installation: GETH_RUN_INSTALL_TESTS=enabled
 deps =
     -r{toxinidir}/requirements-dev.txt
     gevent: -r{toxinidir}/requirements-gevent.txt


### PR DESCRIPTION
### What was wrong?

* The installation scripts for installing specific versions of go-ethereum were not robust and written in bash.
* Not testing against any of the latest versions of geth

### How was it fixed?

* Rewrote installation scripts to be usable as first-class feature of the library.
* TODO: Expand test suite to cover up through `1.6.6`

#### Cute Animal Picture

![gorilla-baby-2016-web4](https://user-images.githubusercontent.com/824194/27881835-5a350148-6187-11e7-812e-ee2fddf6657f.jpg)
